### PR TITLE
fix: remove requestforms references (MTI-5812)

### DIFF
--- a/wp-content/themes/uwa/header-lp.php
+++ b/wp-content/themes/uwa/header-lp.php
@@ -31,7 +31,6 @@
 		</style>
 
 		<?php wp_head(); ?>
-		<script type="text/javascript" src="https://requestforms.learninghouse.com/form/affiliate/734"></script>
 		<?php /*<script>!function(a){"use strict";var b=function(b,c,d){function j(a){return e.body?a():void setTimeout(function(){j(a)})}function l(){f.addEventListener&&f.removeEventListener("load",l),f.media=d||"all"}var g,e=a.document,f=e.createElement("link");if(c)g=c;else{var h=(e.body||e.getElementsByTagName("head")[0]).childNodes;g=h[h.length-1]}var i=e.styleSheets;f.rel="stylesheet",f.href=b,f.media="only x",j(function(){g.parentNode.insertBefore(f,c?g:g.nextSibling)});var k=function(a){for(var b=f.href,c=i.length;c--;)if(i[c].href===b)return a();setTimeout(function(){k(a)})};return f.addEventListener&&f.addEventListener("load",l),f.onloadcssdefined=k,k(l),f};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b}("undefined"!=typeof global?global:this);</script>
 		<script>loadCSS( "/wp-content/themes/uwa/library/css/build/minified/lp-style.css" );</script>
 <noscript><link rel="stylesheet" href="/wp-content/themes/uwa/library/css/build/minified/lp-style.css"></noscript> */ ?>

--- a/wp-content/themes/uwa/header.php
+++ b/wp-content/themes/uwa/header.php
@@ -37,7 +37,6 @@
 
 		<?php // wordpress head functions ?>
 		<?php wp_head(); ?>
-		<script type="text/javascript" src="https://requestforms.learninghouse.com/form/affiliate/734"></script>
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.js"></script>
 
 

--- a/wp-content/themes/uwa/library/bones.php
+++ b/wp-content/themes/uwa/library/bones.php
@@ -187,9 +187,6 @@ function bones_scripts_and_styles()
 		// modernizr (without media query polyfill)
 		// wp_register_script( 'bones-modernizr', get_stylesheet_directory_uri() . '/library/js/libs/modernizr.custom.min.js', array(), '2.5.3', false );
 
-		// form validation and tracking script
-		wp_register_script('form-script', 'https://requestforms.learninghouse.com/form/affiliate/734', array('jquery'), '1.0', false);
-
 		// ie-only style sheet
 		wp_register_style('bones-ie-only', get_stylesheet_directory_uri() . '/library/css/ie.css', array(), '');
 
@@ -232,7 +229,6 @@ function bones_scripts_and_styles()
 
 		// enqueue styles and scripts
 		wp_enqueue_script('bones-modernizr');
-		wp_enqueue_script('form-script');
 
 		if (!is_singular('landing-pages')) {
 			wp_enqueue_style('bones-ie-only');

--- a/wp-content/themes/uwa/scholarship-partnership-single-template.php
+++ b/wp-content/themes/uwa/scholarship-partnership-single-template.php
@@ -21,21 +21,6 @@ form {
 	color: white !important;
 }
 </style>
-<?php
-	global $post;
-
-
-	if (is_page('Teacher Connect')) {
-		$form_template = 'single-step-partners';
-	} elseif (is_page('Business Connect Scholarship')) {
-		$form_template = 'single-step-partners-business';
-	} else {
-		$form_template = 'olc';
-	}
-
-	$form_script_url = 'https://requestforms.learninghouse.com/form/show/university-west-alabama/' . $form_template . '/734/3589/online.uwa.edu:thank-you:request_id';
-?>
-
 			<div class="content">
 				<main class="main-content cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 

--- a/wp-content/themes/uwa/sidebar.php
+++ b/wp-content/themes/uwa/sidebar.php
@@ -2,7 +2,7 @@
 
 					<div class="sidebar-well">
 						<h2 class="h3">Request Your Info Packet</h2>
-						<script src="https://requestforms.learninghouse.com/form/show/university-west-alabama/ppc-form-multi/734/3589/online.uwa.edu:thank-you:request_id" type="text/javascript"></script>
+						<div id="tlh-form"></div>
 					</div>
 
 					<?php

--- a/wp-content/themes/uwa/single.php
+++ b/wp-content/themes/uwa/single.php
@@ -40,7 +40,7 @@
 
 								<div class="formWrapper">
 									<h2 class="h3 formWrapper__heading">Request Your Info Packet</h2>
-									<script src="https://requestforms.learninghouse.com/form/show/university-west-alabama/ppc-form-multi/734/3589/online.uwa.edu:thank-you:request_id" type="text/javascript"></script>
+									<div id="tlh-form"></div>
 								</div>
 
 						<?php dynamic_sidebar( 'Sidebar Blog' ); ?>

--- a/wp-content/themes/uwa/teacher-connect-single-template.php
+++ b/wp-content/themes/uwa/teacher-connect-single-template.php
@@ -47,7 +47,7 @@
 										<h3 class="decorativeForm__heading decorative decorative_red">Request Info</h3>
 										<p class="decorativeForm__prompt">What degree are you interested in?</p>
 									</div>
-									<script src="https://requestforms.learninghouse.com/form/show/university-west-alabama/single-step-partners/734/3589/online.uwa.edu:thank-you:request_id" type="text/javascript"></script>
+									<div id="tlh-form-mobile" class="tlh-form"></div>
 								</div>
 							</div>
 							<?php if (get_field('content_text')): ?>
@@ -116,7 +116,7 @@
 									<h3 class="decorativeForm__heading decorative decorative_red">Request Info</h3>
 									<p class="decorativeForm__prompt">What degree are you interested in?</p>
 								</div>
-								<script src="https://requestforms.learninghouse.com/form/show/university-west-alabama/olc/734/3589/online.uwa.edu:thank-you:request_id" type="text/javascript"></script>
+								<div id="tlh-form" class="tlh-form"></div>
 							</div>
 						</div>
 


### PR DESCRIPTION
This covers both the main site as well as the LP. Most of this one was fairly straightforward in removing and replacing references. However, one of the pages stands out just a bit in comparison to the others. On `wp-content/themes/uwa/teacher-connect.php` there were two references to request forms. One for mobile and one for desktop. Upon inspecting these in production, they are already using TLH Forms rather than requestforms, and have been named `tlh-form-mobile` and `tlh-form`. I've reproduced this in the code in order to follow suit with what is working currently.